### PR TITLE
Fixing Notification URL conflicts with Job Request Overlay Feature

### DIFF
--- a/johnslist/dbtest/models.py
+++ b/johnslist/dbtest/models.py
@@ -134,7 +134,7 @@ def add_perms_job(sender,**kwargs):
     else:
         #notify users of changed JobRequest
         if job.closed:
-            jobrequests = job.jobrequests_accepted();
+            jobrequests = job.jobrequests_accepted()
         else:
             jobrequests = job.jobrequests_accepted() | job.jobrequests_pending()
         for jobrequest in jobrequests:
@@ -142,8 +142,10 @@ def add_perms_job(sender,**kwargs):
                         verb="modified",
                         action_object=jobrequest,
                         recipient=jobrequest.organization.group,
-                        url=reverse('jobrequest_dash',
-                                    kwargs={'organization_id':jobrequest.organization.id,'job_id':job.id}) )
+                        url=reverse('organization_dash',
+                                    kwargs = {'organization_id':jobrequest.organization.id})+
+                                    "?jobrequestID="+str(jobrequest.id)
+                        )
 
 
 class JobRequest(models.Model):
@@ -173,20 +175,17 @@ class JobRequest(models.Model):
                     verb="accepted",
                     action_object=self.job,
                     recipient=self.job.creator,
-                    url=reverse('jobrequest_dash',
-                                kwargs={'organization_id':self.organization.id,'job_id':self.job.id}) )
+                    url=reverse('job_dash',
+                                kwargs={'job_id': self.job.id}) +
+                                "?jobrequestID=" + str(self.id)
+                    )
 
     # set a JobRequest as pending
     def pend(self):
         self.accepted = False
         self.declined = False
         self.save()
-        notify.send(self.organization,
-                    verb="accepted",
-                    action_object=self.job,
-                    recipient=self.job.creator,
-                    url=reverse('jobrequest_dash',
-                                kwargs={'organization_id':self.organization.id,'job_id':self.job.id}) )
+        # shouldn't send a notification to either side of the users. Only superuser should be able to do this.
 
     # set a JobRequest as declined
     def decline(self):
@@ -197,8 +196,10 @@ class JobRequest(models.Model):
                     verb="declined",
                     action_object=self.job,
                     recipient=self.job.creator,
-                    url=reverse('jobrequest_dash',
-                                kwargs={'organization_id':self.organization.id,'job_id':self.job.id}) )
+                    url=reverse('job_dash',
+                                kwargs={'job_id': self.job.id}) +
+                                "?jobrequestID=" + str(self.id)
+                    )
 
     #set a JobRequest as confirmed
     def confirm(self):
@@ -210,8 +211,10 @@ class JobRequest(models.Model):
                     verb="confirmed",
                     action_object=self.job,
                     recipient=self.organization.group,
-                    url=reverse('jobrequest_dash',
-                                kwargs={'organization_id':self.organization.id,'job_id':self.job.id}) )
+                    url=reverse('organization_dash',
+                                kwargs={'organization_id': self.organization.id}) +
+                                "?jobrequestID=" + str(self.id)
+                    )
         # iterate through all jobrequests in this job and remove permission for other jobrequests 
         job = self.job
         job.closed = True
@@ -224,8 +227,11 @@ class JobRequest(models.Model):
                         verb="has closed the job: ",
                             action_object=self.job,
                             recipient=jr.organization.group,
-                            url=reverse('jobrequest_dash',
-                                        kwargs={'organization_id':jr.organization.id,'job_id':jr.job.id}) )
+                            # questionable use of url since user will not have permission to view anymore
+                            # url=reverse('organization_dash',
+                            #            kwargs={'organization_id': jr.organization.id}) +
+                            #            "?jobrequestID=" + str(jr.id)
+                            )
 
    #check if a jobrequest is pending 
     def is_pending(self):
@@ -256,8 +262,10 @@ def jobrequest_save(sender,**kwargs):
                     verb="submitted",
                     action_object=jobrequest,
                     recipient=jobrequest.organization.group,
-                    url=reverse('jobrequest_dash',
-                                kwargs={'organization_id':jobrequest.organization.id,'job_id':job.id}) )
+                    url=reverse('organization_dash',
+                                kwargs={'organization_id': jobrequest.organization.id}) +
+                                "?jobrequestID=" + str(jobrequest.id)
+                    )
 
 #add default jobrequest permissions
 @receiver(pre_delete, sender=JobRequest)

--- a/johnslist/dbtest/static/js/JobRequestOverlay.js
+++ b/johnslist/dbtest/static/js/JobRequestOverlay.js
@@ -1,0 +1,64 @@
+/**
+ * Created by mattchiou1 on 10/2/16.
+ */
+    $(document).ready(function(){
+        jrIDStr = getQueryVariable('jobrequestID');
+        if (jrIDStr) {
+            jrID = parseInt(jrIDStr);
+            showOverlay(jrID)
+        }
+    });
+    var ESC_KEY = 27; // ecs key value
+
+    function closeOverlay() {
+        $(".jobrequest-overlay:visible").hide();
+        $(".jobrequest-overlay-contain").hide();
+        jrIDStr = getQueryVariable('jobrequestID');
+        if (getQueryVariable('jobrequestID')) {
+            window.history.replaceState(null,null,'dash');
+        }
+    }
+    function showOverlay(jobrequestID) { // jobrequestID should be an integer instead of a string here
+        $(".jobrequest-overlay-contain").show();
+        $('[overlayID="'+jobrequestID+'"]').show();
+        window.history.replaceState(null,null,'dash?jobrequestID='+jobrequestID);
+    }
+    function showEventOverlay(event){
+        event.preventDefault();
+        event.stopPropagation();
+        var jobrequestID;
+        if ($(event.target).hasClass("jobrequest-overlay-trigger")) {
+            jobrequestID = $(event.target).attr("jobrequestID");
+        } else {
+            jobrequestID = $(event.target).parent().attr("jobrequestID");
+        }
+        showOverlay(jobrequestID)
+    }
+
+    $(".jobrequest-overlay-trigger").click(showEventOverlay);
+
+    $(".jobrequest-overlay-contain").click(function(event){
+        event.stopPropagation();
+
+        // this prevent the event getting triggered when clicking overlay
+        if ($(event.target).hasClass("jobrequest-overlay-contain") || $(event.target).hasClass("exit-overlay")) {
+            closeOverlay();
+        }
+    }).css({ // set the height and width to fit
+        height: $(window).height(),
+        width: $(window).width()
+    });
+
+    $(window).resize(function (event) { // handle the window resize
+       $(".jobrequest-overlay-contain").css({
+           height: $(window).height(),
+           width: $(window).width()
+       }) ;
+    });
+
+    $(document).keydown(function (event) {
+        // if the key pressed is ESC or jobrequest-overlay-contain is visible
+        if (event.which == ESC_KEY && $(".jobrequest-overlay-contain:visible")[0]) {
+            closeOverlay();
+        }
+    });

--- a/johnslist/dbtest/static/js/Utilities.js
+++ b/johnslist/dbtest/static/js/Utilities.js
@@ -1,0 +1,12 @@
+/**
+ * Created by mattchiou1 on 10/1/16.
+ */
+function getQueryVariable(variable) {
+       var query = window.location.search.substring(1);
+       var vars = query.split("&");
+       for (var i=0;i<vars.length;i++) {
+               var pair = vars[i].split("=");
+               if(pair[0] == variable){return pair[1];}
+       }
+       return(false);
+}

--- a/johnslist/dbtest/templates/dbtest/base.html
+++ b/johnslist/dbtest/templates/dbtest/base.html
@@ -8,7 +8,8 @@
         <link rel='stylesheet' type='text/css' href="{% static 'bootstrap.min.css' %}"/>-->
 
         <link rel="icon" type="image/png" href='{% static 'favicon.png' %}'/>
-        <script src="{% static 'jquery.min.js' %}"></script>
+        <script type='text/javascript' src="{% static 'jquery.min.js' %}"></script>
+        <script type='text/javascript' src="{{ STATIC_URL }}js/Utilities.js"></script>
         <script type='text/javascript' src="{% static 'bootstrap.min.js' %}"></script>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
 

--- a/johnslist/dbtest/templates/dbtest/job_dash.html
+++ b/johnslist/dbtest/templates/dbtest/job_dash.html
@@ -60,55 +60,6 @@
 </div>
 
 <!--this message appears for new user only -->
-<script>
-    var ESC_KEY = 27; // ecs key value
-
-    function closeOverlay() {
-        $(".jobrequest-overlay:visible").hide();
-        $(".jobrequest-overlay-contain").hide();
-    }
-
-    function showOverlay(event){
-        event.preventDefault();
-        event.stopPropagation();
-        var jobrequestID;
-        if ($(event.target).hasClass("jobrequest-overlay-trigger")) {
-            jobrequestID = $(event.target).attr("jobrequestID");
-        } else {
-            jobrequestID = $(event.target).parent().attr("jobrequestID");
-        }
-
-        $(".jobrequest-overlay-contain").show();
-        $('[overlayID="'+jobrequestID+'"]').show();
-    }
-
-    $(".jobrequest-overlay-trigger").click(showOverlay);
-
-    $(".jobrequest-overlay-contain").click(function(event){
-        event.stopPropagation();
-
-        // this prevent the event getting triggered when clicking overlay
-        if ($(event.target).hasClass("jobrequest-overlay-contain") || $(event.target).hasClass("exit-overlay")) {
-            closeOverlay();
-        }
-    }).css({ // set the height and width to fit
-        height: $(window).height(),
-        width: $(window).width()
-    });
-
-    $(window).resize(function (event) { // handle the window resize
-       $(".jobrequest-overlay-contain").css({
-           height: $(window).height(),
-           width: $(window).width()
-       }) ;
-    });
-
-    $(document).keydown(function (event) {
-        // if the key pressed is ESC or jobrequest-overlay-contain is visible
-        if (event.which == ESC_KEY && $(".jobrequest-overlay-contain:visible")[0]) {
-            closeOverlay();
-        }
-    });
-</script>
+<script type='text/javascript' src="{{ STATIC_URL }}js/JobRequestOverlay.js"></script>
 {% endblock content %}
 

--- a/johnslist/dbtest/templates/dbtest/organization_dash.html
+++ b/johnslist/dbtest/templates/dbtest/organization_dash.html
@@ -55,55 +55,5 @@
     </div>
   </div>
 </div>
-
-<script>
-    var ESC_KEY = 27; // ecs key value
-
-    function closeOverlay() {
-        $(".jobrequest-overlay:visible").hide();
-        $(".jobrequest-overlay-contain").hide();
-    }
-
-    function showOverlay(event){
-        event.preventDefault();
-        event.stopPropagation();
-        var jobrequestID;
-        if ($(event.target).hasClass("jobrequest-overlay-trigger")) {
-            jobrequestID = $(event.target).attr("jobrequestID");
-        } else {
-            jobrequestID = $(event.target).parent().attr("jobrequestID");
-        }
-
-        $(".jobrequest-overlay-contain").show();
-        $('[overlayID="'+jobrequestID+'"]').show();
-    }
-
-    $(".jobrequest-overlay-trigger").click(showOverlay);
-
-    $(".jobrequest-overlay-contain").click(function(event){
-        event.stopPropagation();
-
-        // this prevent the event getting triggered when clicking overlay
-        if ($(event.target).hasClass("jobrequest-overlay-contain") || $(event.target).hasClass("exit-overlay")) {
-            closeOverlay();
-        }
-    }).css({ // set the height and width to fit
-        height: $(window).height(),
-        width: $(window).width()
-    });
-
-    $(window).resize(function (event) { // handle the window resize
-       $(".jobrequest-overlay-contain").css({
-           height: $(window).height(),
-           width: $(window).width()
-       }) ;
-    });
-
-    $(document).keydown(function (event) {
-        // if the key pressed is ESC or jobrequest-overlay-contain is visible
-        if (event.which == ESC_KEY && $(".jobrequest-overlay-contain:visible")[0]) {
-            closeOverlay();
-        }
-    });
-</script>
+<script type='text/javascript' src="{{ STATIC_URL }}js/JobRequestOverlay.js"></script>
 {% endblock content %}

--- a/johnslist/dbtest/urls.py
+++ b/johnslist/dbtest/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
     url(r'^organization/create/?$', views.organization_create,name='organization_create'),
     url(r'^organization/(?P<organization_id>[0-9]+)/edit/?$', views.organization_settings,name='organization_settings'),
     #job urls
-    url(r'^job/(?P<job_id>[0-9]+)/?$', views.job_dash,name='job_dash'),
+    url(r'^job/(?P<job_id>[0-9]+)/dash/?$', views.job_dash,name='job_dash'),
     url(r'^organization/(?P<organization_id>[0-9]+)/job/(?P<job_id>[0-9]+)/?$', views.jobrequest_dash,name='jobrequest_dash'),
     url(r'^job_creation$', views.job_creation,name='job_creation'),
     url(r'^job/(?P<job_id>[0-9]+)/edit/?$', views.job_settings,name='job_settings'),

--- a/johnslist/dbtest/views.py
+++ b/johnslist/dbtest/views.py
@@ -142,7 +142,6 @@ def jobrequest_dash(request,job_id,organization_id):
 
     # this is the jobrequest for a particular organization
     jobrequest = JobRequest.objects.get(job = job, organization = organization)
-    request.session['originalJobrequestID'] = jobrequest.id
     comments = jobrequest.comment_set.all()
     perm_to_edit_jobrequest_state = request.user.has_perm('edit_jobrequest_state',jobrequest)
     form = CommentCreateForm()
@@ -203,10 +202,12 @@ def jobrequest_dash(request,job_id,organization_id):
                 if request.user.userprofile.purdueuser:
                     recipient = job.creator
                     link = request.build_absolute_uri(reverse('jobrequest_dash', kwargs = {'job_id': jobrequest.job.id, 'organization_id': organization_id}))
-                    #send_mail('BoilerConnect - Job Request Accepted', '{0} has commented on your Job Request!. Click on the link to see the comment. {1}'.format(organization.name, link),'boilerconnect1@gmail.com', [jobrequest.job.creator.userprofile.email], fail_silently=False)
+                    send_mail('BoilerConnect - Job Request Accepted', '{0} has commented on your Job Request!. Click on the link to see the comment. {1}'.format(organization.name, link),'boilerconnect1@gmail.com', [jobrequest.job.creator.userprofile.email], fail_silently=False)
+                    url = reverse('job_dash', kwargs={'job_id': job.id})
                 else:
                     recipient = jobrequest.organization.group
-                url = reverse('jobrequest_dash',kwargs={'organization_id':organization.id,'job_id':job.id})
+                    url = reverse('organization_dash', kwargs={'organization_id': organization.id})
+                url = url + "?jobrequestID="+str(jobrequest.id)
                 notify.send(request.user,
                             verb=verb,
                             action_object=action_object,
@@ -216,9 +217,9 @@ def jobrequest_dash(request,job_id,organization_id):
                 message = "The comment cannot be empty."
                 messages.add_message(request, messages.ERROR, message)
         if request.user.userprofile.purdueuser:
-            return HttpResponseRedirect(reverse('organization_dash', kwargs = {'organization_id':organization.id}));
+            return HttpResponseRedirect(reverse('organization_dash', kwargs = {'organization_id':organization.id})+ "?jobrequestID="+str(jobrequest.id))
         else:
-            return HttpResponseRedirect(reverse('job_dash', kwargs={'job_id': job.id}));
+            return HttpResponseRedirect(reverse('job_dash', kwargs={'job_id': job.id})+ "?jobrequestID="+str(jobrequest.id))
     # if request is GET
     return render(request, 'dbtest/jobrequest_dash.html',
                   {'jobrequest':jobrequest,


### PR DESCRIPTION
Changes:
- Adding ?jobrequestID={{id number}} to url when opening the overlay. This additional data is removed when user closes the overlay
- Dashboards now automatically open up the same jobrequest overlay after submitting changes. i.e., comments, apply, not interested.
- Change notification url in views.py and models.py related to jobrequest. Those URLs are now matching with recipients user type and have jobrequestID parameter in the url.
- job_dash url now has /dash in it
- created a javascript directory under static
- moved duplicated javascript code in job_dash and organization_dash into JobRequestOverlay.js

Testing done:
- test.py passed
